### PR TITLE
Allows to use envs values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hydra
-Linux-based OpenGL Sony Action Cam HDR-AS30 viewer and recorder
+Linux-based OpenGL Sony Action Cam HDR-AS30 viewer and recorder (tested on HX50 too)
 
 # usage
 Hydra uses libcurl to connect and download image data over Wi-Fi from a Sony Action Cam.
@@ -33,6 +33,10 @@ git clone https://github.com/gnd/hydra.git
 cd hydra
 make
 ```
+
+Export liveview path for ex.: `export CAM_LV="http://10.0.0.1:60152"`
+
+Export save folder path for ex.: `export SAVE_LV="/mnt/LV/sony_%05d.jpeg"` 
 
 ###
 Inspired by https://github.com/erik-smit/sony-camera-api/blob/master/liveView.py

--- a/hydra.c
+++ b/hydra.c
@@ -145,9 +145,9 @@ void LoadJPEG(const unsigned char *imgdata, JpegDec_t *jpeg_dec, size_t jpeg_siz
 
 void SaveJPEG(JpegMemory_t *mem)
 {
-    char filename[16];
-
-    sprintf(filename, "sony_%05d.jpeg", picture_number);
+    char filename[255];
+    char* slv = getenv("SAVE_LV");
+    sprintf(filename, slv, picture_number);
     FILE *f = fopen(filename, "w");
     if (f == NULL)
     {
@@ -181,6 +181,12 @@ size_t Hydra_InstanceSize(void)
 
 int Hydra_Construct(Hydra *hy)
 {
+    char* lv = getenv("CAM_LV");
+    char* padd = "/liveview.JPG?!1234!http-get:*:image/jpeg:*!!!!!";
+    char* flv = malloc(strlen(lv) + strlen(padd) + 1);
+    strcpy(flv, lv);
+    strcat(flv, padd);
+
     memset(&hy->jpeg_dec, 0, sizeof(hy->jpeg_dec));
     hy->jpeg_dec.x        = 0;
     hy->jpeg_dec.y        = 0;
@@ -221,7 +227,7 @@ int Hydra_Construct(Hydra *hy)
     // setup libcurl
     curl_global_init(CURL_GLOBAL_ALL);
     hy->curl_handle = curl_easy_init();
-    curl_easy_setopt(hy->curl_handle, CURLOPT_URL, "http://192.168.122.1:60152/liveview.JPG?!1234!http-get:*:image/jpeg:*!!!!!");
+    curl_easy_setopt(hy->curl_handle, CURLOPT_URL, flv);
     curl_easy_setopt(hy->curl_handle, CURLOPT_WRITEFUNCTION, SonyCallback);
     curl_easy_setopt(hy->curl_handle, CURLOPT_WRITEDATA, &hy->mem);
 


### PR DESCRIPTION
Allows to use envs values, basically it makes app compatible with wider set of cams without recompiling
For ex. I use `export CAM_LV="http://10.0.0.1:60152"` and `export SAVE_LV="/mnt/LV/sony_%05d.jpeg"` with my HX50. 
